### PR TITLE
Bump Jinja2 and jQuery version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tqdm==4.56.2
 requests==2.25.1
-Jinja2==2.11.3
+Jinja2==3.1.2
 ciscoconfparse==1.5.29
 click==8.0.3
 markupsafe==2.0.1

--- a/src/report/templates/html_template.html
+++ b/src/report/templates/html_template.html
@@ -6,7 +6,7 @@
         <style type="text/css">
             {% include "style.css" %}
         </style>
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+        <script src="https://code.jquery.com/jquery-3.6.3.js" integrity="sha256-nQLuAZGRRcILA+6dMBOvcRh5Pe310sBpanc6+QBmyVM=" crossorigin="anonymous"></script>
     </head>
 
     <body class="mainbody">


### PR DESCRIPTION
## Motivation

### jQuery

Bump the version due to medium security vulnerabilities: https://security.snyk.io/package/npm/jquery/1.9.1

Closes #67 

### Jinja2

Bump templates to improve features